### PR TITLE
Update CFBinaryPropertyList.php

### DIFF
--- a/src/CFPropertyList/CFBinaryPropertyList.php
+++ b/src/CFPropertyList/CFBinaryPropertyList.php
@@ -941,7 +941,7 @@ abstract class CFBinaryPropertyList
     protected static function binaryStrlen($val)
     {
         for ($i=0; $i<strlen($val); ++$i) {
-            if (ord($val{$i}) >= 128) {
+            if (ord($val[$i]) >= 128) {
                 $val = self::convertCharset($val, 'UTF-8', 'UTF-16BE');
                 return strlen($val);
             }
@@ -965,7 +965,7 @@ abstract class CFBinaryPropertyList
             $utf16 = false;
 
             for ($i=0; $i<strlen($val); ++$i) {
-                if (ord($val{$i}) >= 128) {
+                if (ord($val[$i]) >= 128) {
                     $utf16 = true;
                     break;
                 }


### PR DESCRIPTION
fix: String offset access syntax with curly braces is deprecated in php >= 7.4, fixed in CFBinaryPropertyList.php

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A